### PR TITLE
Create new filter `rkvcss_before_minify`

### DIFF
--- a/reaktiv-css-builder.php
+++ b/reaktiv-css-builder.php
@@ -253,6 +253,14 @@ class RKV_Custom_CSS_Builder {
 		// get the new CSS
 		$css	= $this->get_css_code();
 
+		/**
+		 * Allow developers to inject separate css into the file
+		 * without having to save it in the reaktiv-custom-css option
+		 * 
+		 * @var string $css
+		 */
+		$css = apply_filters( 'rkvcss_before_minify', $css );
+
 		// run through minification
 		$css	= $this->minify_css( $css );
 


### PR DESCRIPTION
This would give developers the ability to hook some CSS  before reaktiv saves the .css file. Could be used when saving css that is controlled in something like an options panel. That way they wouldn't have to inject their css into the head or have to enqueue another script.
